### PR TITLE
fix: zsh plugin working correctly

### DIFF
--- a/config/default_imports
+++ b/config/default_imports
@@ -138,7 +138,7 @@ function activate_venv() {
     fi
 }
 
-functionformat_args() {
+function format_args() {
     local args="$1"
     if [ ${#args} -gt 1 ]; then
         echo " $args "

--- a/zsh-plugin/av.plugin.zsh
+++ b/zsh-plugin/av.plugin.zsh
@@ -1,7 +1,10 @@
 # AV Plugin from:
 export __AV_PROMPT_DIR=$ZSH/plugins/av
-AV_COMMAND=`which av`
-if [ -z "$AV_COMMAND" ]; then
+if [ -f ~/.local/bin/av ]; then
+    AV_COMMAND=~/.local/bin/av
+elif [ -f /usr/local/bin/av ]; then
+    AV_COMMAND=/usr/local/bin/av
+else
     return
 fi
 


### PR DESCRIPTION
Error was:
```
av:4: command not found: av not found
av:5: command not found: av not found
```